### PR TITLE
Mention 2.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ $ brew upgrade --fetch-HEAD scalaenv
 
 ### Version History
 
+**Unreleased**
+  * Added **Scala 2.12.1**.
+    Thanks to @3tty0n.
+
 **0.0.10** (Dec 05, 2016)
 
   * Added **Scala 2.11.8**, **Scala 2.12.0-M4** - **2.12.0**.


### PR DESCRIPTION
Since 2.12.1 wasn't mentioned by the README I thought it was missing, then I found https://github.com/mazgi/scalaenv/pull/32.

Not sure re: release policy, apologies if this is unwarranted.